### PR TITLE
Add ZipCode Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -1,9 +1,40 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 
+@Tag(name="Zip Code info from https://www.zippopotam.us")
+@Slf4j
 @RestController
+@RequestMapping("/api/zipcode")
 public class ZipCodeController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ZipCodeQueryService zipCodeQueryService;
+
+    @Operation(summary="Get information about a us zipcode", description = "JSON return format documented here: https://www.zippopotam.us")
+    @GetMapping("/get")
+    public ResponseEntity<String> getZipCodes(
+        @Parameter(name="zipcode", description="US zipcode, e.g. 93106", example="93106") @RequestParam String zipcode
+    ) throws JsonProcessingException {
+        log.info("getZipCodes: zipcode={}", zipcode);
+        String result = zipCodeQueryService.getJSON(zipcode);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -2,11 +2,21 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 import org.springframework.web.client.RestTemplate;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import java.util.List;
+import java.util.Map;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 public class ZipCodeQueryService {
 
@@ -16,9 +26,20 @@ public class ZipCodeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
-       return "";
+        log.info("zipcode={}", zipcode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = ZipCodeController.class)
+public class ZipCodeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  ZipCodeQueryService mockCountryCodeQueryService;
+
+
+  @Test
+  public void test_getCountryCodes() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    // String country = "United States";
+    String zipcode = "93106";
+    when(mockCountryCodeQueryService.getJSON(eq(zipcode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/zipcode/get?zipcode=%s", zipcode);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(ZipCodeQueryService.class)
+public class ZipCodeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private ZipCodeQueryService zipCodeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String zipcode = "93106";
+        String expectedURL = ZipCodeQueryService.ENDPOINT.replace("{zipcode}", zipcode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = zipCodeQueryService.getJSON(zipcode);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information
about the location of a particular zipcode.
Dokku deployment link: [https://team01-ethan-dev.dokku-04.cs.ucsb.edu/swagger-ui/index.html](url)

Closes #13 #14